### PR TITLE
prevent bash wildcard expansion

### DIFF
--- a/par_psql
+++ b/par_psql
@@ -103,14 +103,14 @@ parseloop() {
   # If you don't see a semicolon or parpsqlmarker, keep writing to the current file
   elif [[ "$semicolon" -eq 0 && "$parpsqlmarker" -eq 0 ]]; then 
 	debug 'No change of mode. Continuing to write to file'; 
-	echo $sqlline >> $currentfile
+	echo "$sqlline" >> $currentfile
 
   # if you see a semicolon and a parpsqlmarker together, and are in parallel mode, 
   elif [[ "$semicolon" -ne 0 && "$parpsqlmarker" -ne 0 && "$parmode" -ne 0 ]]; then 
 	debug 'parpsql marker found; in parallel mode already; staying in parallel mode'
 
   # write the current line out to currentfile
-	echo $sqlline >> $currentfile
+	echo "$sqlline" >> $currentfile
 
   # start running the current file in parallel
 	( eval psql "$cmdline" --file=$currentfile && rm -f "$currentfile" ) &  
@@ -123,7 +123,7 @@ parseloop() {
 	debug 'parpsql marker found; in serial mode; changing to parallel mode'
 
   # write the current line out to the current file
-	echo $sqlline >> $currentfile
+	echo "$sqlline" >> $currentfile
 
   # first, run the 'serial code' file that was previously built up, non-parallelised
   # wait for it to finish
@@ -149,7 +149,7 @@ parseloop() {
 	wait
 
   # Save the current line to the current file.
- 	echo $sqlline >> $currentfile	
+ 	echo "$sqlline" >> $currentfile	
 
   # concatenate the current file to serial-to-do
 	cat $currentfile >> $serialtodofile
@@ -170,7 +170,7 @@ parseloop() {
 	debug 'staying in serial mode'
 
   # Save line to current file.
- 	echo $sqlline >> $currentfile	
+ 	echo "$sqlline" >> $currentfile	
 
   # Save the current file into serialtodofile
 	cat $currentfile >> $serialtodofile


### PR DESCRIPTION
Handle multiline comments in SQL:
```
/*
This is also a comment
*/
```
other wise `/*` gets expanded by the shell:
```
psql:/var/folders/3v/mkws3tfx0hg0t9txdj0y6tn0gfkbl4/T/tmp.lG9dCzyP:4: ERROR:  syntax error at or near "/"
LINE 1: /Applications /Library /Network /System /Users /Volumes /bin...
```